### PR TITLE
Fix `valid`

### DIFF
--- a/example/example.odin
+++ b/example/example.odin
@@ -37,6 +37,8 @@ main :: proc() {
 		color = rl.BLACK,
 	})
 
+	assert(hm.valid(entities, player), "The player entity is invalid.")
+
 	for !rl.WindowShouldClose() {
 		update()
 		draw()

--- a/example_web/example_web.odin
+++ b/example_web/example_web.odin
@@ -47,6 +47,8 @@ main_start :: proc "c" () {
 		size = 30,
 		color = rl.BLACK,
 	})
+
+	assert(hm.valid(entities, player), "The player entity is invalid.")
 }
 
 @export

--- a/handle_map/handle_map.odin
+++ b/handle_map/handle_map.odin
@@ -192,7 +192,7 @@ remove :: proc(m: ^Handle_Map($T, $HT), h: HT) {
 
 // Tells you if a handle maps to a valid item.
 valid :: proc(m: Handle_Map($T, $HT), h: HT) -> bool {
-	return get_ptr(m, h) != nil
+	return get(m, h) != nil
 }
 
 // Tells you how many valid items there are in the handle map. Note how this


### PR DESCRIPTION
I was having a read of the code and noticed a small bug.

This PR changes the call of `get_ptr` to `get`, which looks like it was missed in 24454fef47a27fb1679288b63848ea113c93515c. This wouldn't have been detected by building the examples since it's a procedure with a polymorphic parameter and thus not checked if not used, so I added a call to `valid` to both examples.